### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Dictionary Development Kit :closed_book:
 
 This is a mirror of Apple's Dictionary Development Kit to give more Developers access to this package.
-It is part of the [Auxilliary Tools for Xcode - October 2013](https://developer.apple.com/downloads/index.action?name=for%20Xcode%20-).
+It is part of the [Auxiliary Tools for Xcode - October 2013](https://developer.apple.com/downloads/index.action?name=for%20Xcode%20-).
 
 The Dictionary Development Kit lets you create your own custom dictionaries that users can access through the Dictionary application.
 


### PR DESCRIPTION
SebastianSzturo, I've corrected a typographical error in the documentation of the [Dictionary-Development-Kit](https://github.com/SebastianSzturo/Dictionary-Development-Kit) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
